### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,8 +3,8 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    #@items = Item.order("created_at DESC")
-  end
+    @items = Item.order("created_at DESC") #order("created_at DESC")で、新しく投稿された分から表示する様に並べ替えている
+  end   
   
   def new
     @item = Item.new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.order("created_at DESC") #order("created_at DESC")で、新しく投稿された分から表示する様に並べ替えている
+    @items = Item.order("created_at DESC").includes(:user) #order("created_at DESC")で、新しく投稿された分から表示する様に並べ替えている
   end   
   
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,7 @@ class ItemsController < ApplicationController
   end
 
   def create
-    @item = Item.new#create(item_params)
+    @item = Item.create(item_params)
     if @item.save
       redirect_to root_path
     else

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,60 +126,57 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <% if @items %> <%# 商品のインスタンス変数になにか入っている場合、コントローラーで定義したインスタンスから取り出し%>
+      <% if @items.length != 0 %> <%# 商品のインスタンス変数になにか入っている場合、コントローラーで定義したインスタンスから取り出し%>
         <% @items.each do |item| %> <%# 一覧表示させたいので、eachを使って配列の中身を取り出し表示を行う%>
-          <% if %>
-            <li class='list'>
-              <%= link_to "#" do %>
-              <div class='item-img-content'>
-                <%= image_tag item.image, class: "item-img" if item.image.attached?  %> <%# if item.image.attached?で、ブロック変数の中に値がある場合のみ表示させる%>
+          <li class='list'>
+            <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" if item.image.attached?  %> <%# if item.image.attached?で、ブロック変数の中に値がある場合のみ表示させる%>
 
-                <%# 商品が売れていればsold outを表示しましょう %>
-                <div class='sold-out'>
-                  <span>Sold Out!!</span>
-                </div>
-                <%# //商品が売れていればsold outを表示しましょう %>
-
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
               </div>
-              <div class='item-info'>
-                <h3 class='item-name'>
-                  <%= item.product_name %>
-                </h3>
-                <div class='item-price'>
-                  <span><%= item.price %>円<br><%= item.burden.name %></span> <%# itemモデルのアクティブハッシュburdenモデルのnameカラムから取り出し%>
-                  <div class='star-btn'>
-                    <%= image_tag "star.png", class:"star-icon" %>
-                    <span class='star-count'>0</span>
-                  </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
+
+            </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.product_name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= item.burden.name %></span> <%# itemモデルのアクティブハッシュburdenモデルのnameカラムから取り出し%>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
                 </div>
               </div>
-              <% end %>
-            </li>
-
+            </div>
+            <% end %>
+          </li>
+        <% end %>
             <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
             <%# 商品がある場合は表示されないようにしましょう %>
-          <% else %>
-            <li class='list'>
-              <%= link_to '#' do %>
-              <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-              <div class='item-info'>
-                <h3 class='item-name'>
-                  商品を出品してね！
-                </h3>
-                <div class='item-price'>
-                  <span>99999999円<br>(税込み)</span>
-                  <div class='star-btn'>
-                    <%= image_tag "star.png", class:"star-icon" %>
-                    <span class='star-count'>0</span>
-                  </div>
-                </div>
+      <% else %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
               </div>
-              <% end %>
-            </li>
+            </div>
+          </div>
+          <% end %>
+        </li>
             <%# //商品がある場合は表示されないようにしましょう %>
             <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-          <% end %>
-        <% end %>
       <% end %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,56 +128,59 @@
 
       <% if @items %> <%# 商品のインスタンス変数になにか入っている場合、コントローラーで定義したインスタンスから取り出し%>
         <% @items.each do |item| %> <%# 一覧表示させたいので、eachを使って配列の中身を取り出し表示を行う%>
-          <li class='list'>
-            <%= link_to "#" do %>
-            <div class='item-img-content'>
-              <%= image_tag item.image, class: "item-img" if item.image.attached?  %> <%# if item.image.attached?で、ブロック変数の中に値がある場合のみ表示させる%>
+          <% if %>
+            <li class='list'>
+              <%= link_to "#" do %>
+              <div class='item-img-content'>
+                <%= image_tag item.image, class: "item-img" if item.image.attached?  %> <%# if item.image.attached?で、ブロック変数の中に値がある場合のみ表示させる%>
 
-              <%# 商品が売れていればsold outを表示しましょう %>
-              <div class='sold-out'>
-                <span>Sold Out!!</span>
+                <%# 商品が売れていればsold outを表示しましょう %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+                <%# //商品が売れていればsold outを表示しましょう %>
+
               </div>
-              <%# //商品が売れていればsold outを表示しましょう %>
-
-            </div>
-            <div class='item-info'>
-              <h3 class='item-name'>
-                <%= item.product_name %>
-              </h3>
-              <div class='item-price'>
-                <span><%= item.price %>円<br><%= item.burden.name %></span> <%# itemモデルのアクティブハッシュburdenモデルのnameカラムから取り出し%>
-                <div class='star-btn'>
-                  <%= image_tag "star.png", class:"star-icon" %>
-                  <span class='star-count'>0</span>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.product_name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br><%= item.burden.name %></span> <%# itemモデルのアクティブハッシュburdenモデルのnameカラムから取り出し%>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
                 </div>
               </div>
-            </div>
-            <% end %>
-          </li>
+              <% end %>
+            </li>
+
+            <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+            <%# 商品がある場合は表示されないようにしましょう %>
+          <% else %>
+            <li class='list'>
+              <%= link_to '#' do %>
+              <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  商品を出品してね！
+                </h3>
+                <div class='item-price'>
+                  <span>99999999円<br>(税込み)</span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+              <% end %>
+            </li>
+            <%# //商品がある場合は表示されないようにしましょう %>
+            <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
         <% end %>
       <% end %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,34 +126,36 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% if @items %> <%# 商品のインスタンス変数になにか入っている場合、コントローラーで定義したインスタンスから取り出し%>
+        <% @items.each do |item| %> <%# 一覧表示させたいので、eachを使って配列の中身を取り出し表示を行う%>
+          <li class='list'>
+            <%= link_to "#" do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" if item.image.attached?  %> <%# if item.image.attached?で、ブロック変数の中に値がある場合のみ表示させる%>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
             </div>
-          </div>
-        </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.product_name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= item.burden.name %></span> <%# itemモデルのアクティブハッシュburdenモデルのnameカラムから取り出し%>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+            <% end %>
+          </li>
         <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>


### PR DESCRIPTION
# What
商品一覧機能の実装

# Why
index画面上に、商品一覧を表示させるための作業

### 以下画像

1.ログイン状態で、画像が表示されており、商品一覧が表示されている
https://gyazo.com/d99987686a839975342161fa6175cccf

2.上から、出品された日時が新しい順に表示されている
https://gyazo.com/0d3e0648bfb2f56a4b66aa20e47bb83a
https://gyazo.com/73111cccd4a01ce3acb0a991444140a1

3.「画像/価格/商品名」の3つの情報について表示できている
https://gyazo.com/ab9686f4bd03fef52fab4faf489f6740

4.ログアウト状態で、画像が表示されており、商品一覧が表示されている
https://gyazo.com/59ccf7078de72638eb068e8f8e12bc6e


以上です。
ご確認お願い致します。